### PR TITLE
Added plugin to remove unused element names

### DIFF
--- a/src/lib/avocado.ts
+++ b/src/lib/avocado.ts
@@ -13,6 +13,7 @@ import { removeDefaults } from '../plugins/removeDefaults';
 import { removeEmptyGroups } from '../plugins/removeEmptyGroups';
 import { removeHiddenElems } from '../plugins/removeHiddenElems';
 import { removeXMLProcInst } from '../plugins/removeXMLProcInst';
+import { removeUnusedNames } from '../plugins/removeUnusedNames';
 import { xml2js } from './xml2js';
 
 // The order is from https://github.com/svg/svgo/blob/master/.svgo.yml
@@ -26,6 +27,7 @@ export const plugins: { [name: string]: Plugin } = {
   removeDefaults,
   // removeUselessStrokeAndFill,
   removeHiddenElems,
+  removeUnusedNames,
   bakeGroupTransforms,
   collapseGroups,
   convertPathData,

--- a/src/plugins/removeEmptyGroups.ts
+++ b/src/plugins/removeEmptyGroups.ts
@@ -6,7 +6,6 @@ import { Plugin } from './_types';
  * TODO: are there any empty containers that could be removed in an animated-vector?
  */
 function fn(item: JsApi) {
-  // TODO: detect if the group w/ a name is being referenced by an AVD
   return item.isElem('group') && !item.hasAttr('android:name') && item.isEmpty()
     ? undefined
     : item;

--- a/src/plugins/removeUnusedNames.ts
+++ b/src/plugins/removeUnusedNames.ts
@@ -1,0 +1,50 @@
+import { JsApi } from '../lib/jsapi';
+import { Plugin } from './_types';
+
+/**
+ * Removes names from groups that aren't referenced in any target animations.
+ * These are expected to then be stripped by collapseGroups
+ */
+function fn(item: JsApi) {
+  const findRecursive = (
+    current: JsApi,
+    filter: (node: JsApi) => Boolean,
+    results: JsApi[] = [],
+  ): JsApi[] => {
+    if (filter(current)) {
+      results.push(current);
+    }
+    current.content.forEach(child => {
+      findRecursive(child, filter, results);
+    });
+    return results;
+  };
+
+  const targetAnimationNames: Set<string> = new Set(
+    findRecursive(item, node => node.isElem('target'))
+      .filter(node => node.hasAttr('android:name'))
+      .map(node => node.attr('android:name').value),
+  );
+
+  // If the targets aren't in this file we don't know if the name is used.
+  if (targetAnimationNames.size === 0) {
+    return item;
+  }
+
+  const namedNodes = findRecursive(item, node => node.hasAttr('android:name'));
+  for (const node of namedNodes) {
+    if (!targetAnimationNames.has(node.attr('android:name').value)) {
+      node.removeAttr('android:name');
+    }
+  }
+
+  return item;
+}
+
+export const removeUnusedNames: Plugin<undefined> = {
+  type: 'full',
+  active: true,
+  description: 'Removes unused group names',
+  params: undefined,
+  fn,
+};

--- a/test/plugins/removeUnusedNames.01.xml
+++ b/test/plugins/removeUnusedNames.01.xml
@@ -1,0 +1,33 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector>
+            <group android:name="rotationGroup">
+                <path android:name="v" android:pathData="..."/>
+            </group>
+        </vector>
+    </aapt:attr>
+    <target android:name="v">
+        <aapt:attr name="android:animation">
+            <set>
+                <objectAnimator/>
+            </set>
+        </aapt:attr>
+    </target>
+</animated-vector>
+@@@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector>
+            <group>
+                <path android:name="v" android:pathData="..."/>
+            </group>
+        </vector>
+    </aapt:attr>
+    <target android:name="v">
+        <aapt:attr name="android:animation">
+            <set>
+                <objectAnimator/>
+            </set>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/test/plugins/removeUnusedNames.02.xml
+++ b/test/plugins/removeUnusedNames.02.xml
@@ -1,0 +1,19 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector>
+            <group>
+                <path android:pathData="..."/>
+            </group>
+        </vector>
+    </aapt:attr>
+</animated-vector>
+@@@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector>
+            <group>
+                <path android:pathData="..."/>
+            </group>
+        </vector>
+    </aapt:attr>
+</animated-vector>

--- a/test/plugins/removeUnusedNames.03.xml
+++ b/test/plugins/removeUnusedNames.03.xml
@@ -1,0 +1,43 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector>
+            <group android:name="rotationGroup">
+                <path android:name="v" android:pathData="..."/>
+            </group>
+        </vector>
+    </aapt:attr>
+    <target android:name="rotationGroup">
+        <aapt:attr name="android:animation">
+            <objectAnimator/>
+        </aapt:attr>
+    </target>
+    <target android:name="v">
+        <aapt:attr name="android:animation">
+            <set>
+                <objectAnimator/>
+            </set>
+        </aapt:attr>
+    </target>
+</animated-vector>
+@@@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector>
+            <group android:name="rotationGroup">
+                <path android:name="v" android:pathData="..."/>
+            </group>
+        </vector>
+    </aapt:attr>
+    <target android:name="rotationGroup">
+        <aapt:attr name="android:animation">
+            <objectAnimator/>
+        </aapt:attr>
+    </target>
+    <target android:name="v">
+        <aapt:attr name="android:animation">
+            <set>
+                <objectAnimator/>
+            </set>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/test/plugins/removeUnusedNames.04.xml
+++ b/test/plugins/removeUnusedNames.04.xml
@@ -1,0 +1,29 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector>
+            <group android:name="rotationGroup">
+                <path android:name="v" android:pathData="..."/>
+            </group>
+        </vector>
+    </aapt:attr>
+    <target android:name="rotationGroup">
+        <aapt:attr name="android:animation">
+            <objectAnimator/>
+        </aapt:attr>
+    </target>
+</animated-vector>
+@@@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector>
+            <group android:name="rotationGroup">
+                <path android:pathData="..."/>
+            </group>
+        </vector>
+    </aapt:attr>
+    <target android:name="rotationGroup">
+        <aapt:attr name="android:animation">
+            <objectAnimator/>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/test/plugins/removeUnusedNames.05.xml
+++ b/test/plugins/removeUnusedNames.05.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android">
+    <group android:name="rotationGroup">
+        <path android:name="v" android:pathData="..."/>
+    </group>
+</vector>
+@@@
+<vector xmlns:android="http://schemas.android.com/apk/res/android">
+    <group android:name="rotationGroup">
+        <path android:name="v" android:pathData="..."/>
+    </group>
+</vector>


### PR DESCRIPTION
I'm working on a set of plugins that will hopefully get rid of a bunch of the redundant code that is exported from bodymovin-to-avd. I'm planning on combining this with another plugin that will merge and collapse animations.

I've never worked in typescript before so there is a good chance this code is bad. Feedback/changes are very welcome.